### PR TITLE
feat: #21 강사 및 학생 시간표 컴포넌트 개선 및 오늘의 수업 일정 추가

### DIFF
--- a/src/app/(app)/classes/component/InstructorTimelineView.tsx
+++ b/src/app/(app)/classes/component/InstructorTimelineView.tsx
@@ -1,34 +1,224 @@
 'use client';
 
-import React from 'react';
+import { useMemo } from 'react';
 import { useRouter } from 'next/navigation';
-import { CheckSquare, FileText } from 'lucide-react';
+import { Clock, BookOpen, CalendarDays, AlertCircle, CheckSquare, FileText } from 'lucide-react';
 import Button from '@/components/ui/Button/Button';
 import { ClassData } from '@/types/classes.types';
-import { DAYS_KOR } from '@/utils/timeTable.utils';
 
-export default function InstructorTimelineView({ classes }: { classes: ClassData[] }) {
+// 월(1) ~ 토(6) 매핑 및 필터링용 데이터
+const TARGET_DAYS = [1, 2, 3, 4, 5, 6];
+const DAY_NAMES: Record<number, string> = {
+  1: '월', 2: '화', 3: '수', 4: '목', 5: '금', 6: '토'
+};
+
+// 개별 스케줄을 평탄화(Flatten)하기 위한 인터페이스
+interface InstructorScheduleItem {
+  classId: string;
+  subjectTitle: string;
+  classroomName: string;
+  targetDate: string | Date | null;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+}
+
+export default function InstructorTimelineView({ classes = [] }: { classes?: ClassData[] }) {
   const router = useRouter();
+  const safeClasses = Array.isArray(classes) ? classes : [];
+  
+  // 오늘 요일 (1: 월요일 ~ 6: 토요일)
+  const currentDay = new Date().getDay();
+
+  // 데이터를 요일 및 시간별로 평탄화하고 정렬하는 로직
+  const allSchedules = useMemo(() => {
+    const schedules: InstructorScheduleItem[] = [];
+    
+    safeClasses.forEach((cls) => {
+      if (!cls.schedules) return;
+      
+      cls.schedules.forEach((sched) => {
+        // 월~토(1~6)만 포함
+        if (TARGET_DAYS.includes(sched.dayOfWeek)) {
+          schedules.push({
+            classId: cls._id,
+            subjectTitle: typeof cls.subjectId === 'object' ? cls.subjectId.title : '수업',
+            classroomName: typeof cls.classroomId === 'object' ? cls.classroomId.classroomName : '강의실 미상',
+            targetDate: cls.targetDate || null,
+            dayOfWeek: sched.dayOfWeek,
+            startTime: sched.startTime,
+            endTime: sched.endTime,
+          });
+        }
+      });
+    });
+
+    // 시작 시간 기준으로 오름차순 정렬
+    return schedules.sort((a, b) => a.startTime.localeCompare(b.startTime));
+  }, [safeClasses]);
+
+  // 오늘의 스케줄 필터링
+  const todaysSchedules = useMemo(() => {
+    return allSchedules.filter((s) => s.dayOfWeek === currentDay);
+  }, [allSchedules, currentDay]);
+
+  // 배정된 수업이 없는 경우
+  if (safeClasses.length === 0) {
+    return (
+      <div className="text-center py-10 text-muted bg-paper rounded-3xl border border-border">
+        배정된 수업이 없습니다.
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-4">
-      {classes.map((cls) => (
-        <div key={cls._id} className="bg-paper border border-border rounded-3xl p-6 shadow-sm">
-          <div className="flex justify-between items-start mb-4">
-            <div>
-              <h3 className="text-lg font-bold text-ink">{typeof cls.subjectId === 'object' ? cls.subjectId.title : '수업'}</h3>
-              <p className="text-sm text-muted">{typeof cls.classroomId === 'object' ? cls.classroomId.classroomName : '강의실 미상'}</p>
-            </div>
-            <span className="text-xs font-bold px-3 py-1 bg-primary/10 text-primary rounded-full">{DAYS_KOR[cls.schedules[0]?.dayOfWeek]}요일</span>
-          </div>
-          
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={() => router.push(`/classes/attendance/${cls._id}`)}><CheckSquare className="size-4 mr-1"/>출석부</Button>
-            <Button variant="outline" size="sm" onClick={() => router.push(`/classes/reports/${cls._id}`)}><FileText className="size-4 mr-1"/>수업일지</Button>
-            {/* <Button variant="secondary" size="sm" onClick={() => router.push(`/classes/request/${cls._id}`)}><CalendarPlus className="size-4 mr-1"/>보강/휴강</Button> */}
-          </div>
+    <div className="flex flex-col gap-10">
+      
+      {/* 오늘의 시간표 섹션 */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <AlertCircle className="size-5 text-primary" />
+          <h2 className="text-xl font-extrabold text-ink">오늘의 강의 일정</h2>
         </div>
-      ))}
+        
+        {todaysSchedules.length === 0 ? (
+          <div className="bg-paper border border-border rounded-2xl p-6 text-center text-muted">
+            오늘 예정된 강의가 없습니다.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {todaysSchedules.map((sched, idx) => (
+              <div key={`today-${sched.classId}-${idx}`} className="flex flex-col bg-primary-bg border border-primary/20 rounded-2xl p-5 shadow-sm">
+                
+                <div className="flex justify-between items-start mb-3">
+                  <h3 className="text-lg font-bold text-primary">{sched.subjectTitle}</h3>
+                  {sched.targetDate && (
+                    <span className="text-xs font-bold text-danger bg-danger-bg px-2.5 py-1 rounded-full">
+                      시험 대비
+                    </span>
+                  )}
+                </div>
+                
+                <div className="flex flex-col gap-2 text-sm text-ink font-medium mt-2 flex-1">
+                  <div className="flex items-center gap-2">
+                    <Clock className="size-4 text-primary" />
+                    <span>{sched.startTime} - {sched.endTime}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <BookOpen className="size-4 text-primary" />
+                    <span>{sched.classroomName}</span>
+                  </div>
+                </div>
+
+                {/* 강사 액션 버튼 (출석부, 수업일지) */}
+                <div className="flex gap-2 mt-5 pt-4 border-t border-primary/10">
+                  <Button 
+                    variant="outline" 
+                    size="sm" 
+                    className="flex-1 bg-background text-primary border-primary/20 hover:bg-primary/5"
+                    onClick={() => router.push(`/classes/attendance/${sched.classId}`)}
+                  >
+                    <CheckSquare className="size-4 mr-1.5"/> 출석부
+                  </Button>
+                  <Button 
+                    variant="outline" 
+                    size="sm" 
+                    className="flex-1 bg-background text-primary border-primary/20 hover:bg-primary/5"
+                    onClick={() => router.push(`/classes/reports/${sched.classId}`)}
+                  >
+                    <FileText className="size-4 mr-1.5"/> 수업일지
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* 주간 강의 시간표 섹션 (월~토) */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <CalendarDays className="size-5 text-ink" />
+          <h2 className="text-xl font-extrabold text-ink">주간 강의 시간표</h2>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {TARGET_DAYS.map((day) => {
+            const daySchedules = allSchedules.filter((s) => s.dayOfWeek === day);
+            const isToday = currentDay === day;
+
+            return (
+              <div 
+                key={day} 
+                className={`flex flex-col md:flex-row gap-4 p-5 rounded-2xl border ${
+                  isToday ? 'border-primary bg-primary-bg/50' : 'border-border bg-paper'
+                }`}
+              >
+                {/* 요일 헤더 */}
+                <div className="md:w-20 shrink-0 flex items-center md:items-start gap-2">
+                  <span className={`flex items-center justify-center w-10 h-10 rounded-xl font-extrabold text-lg ${
+                    isToday ? 'bg-primary text-background' : 'bg-border text-ink'
+                  }`}>
+                    {DAY_NAMES[day]}
+                  </span>
+                  {isToday && <span className="text-sm font-bold text-primary md:hidden">오늘</span>}
+                </div>
+
+                {/* 해당 요일의 스케줄 리스트 */}
+                <div className="flex flex-col gap-3 flex-1">
+                  {daySchedules.length > 0 ? (
+                    daySchedules.map((sched, idx) => (
+                      <div key={`weekly-${sched.classId}-${idx}`} className="flex flex-col xl:flex-row xl:items-center justify-between gap-4 p-4 bg-background rounded-xl border border-border shadow-sm">
+                        
+                        {/* 강의 기본 정보 */}
+                        <div className="flex flex-col gap-1">
+                          <span className="font-bold text-ink text-base">{sched.subjectTitle}</span>
+                          <div className="flex items-center gap-3 text-sm font-medium text-muted">
+                            <span className="flex items-center gap-1">
+                              <Clock className="size-3.5" />
+                              {sched.startTime} - {sched.endTime}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <BookOpen className="size-3.5" />
+                              {sched.classroomName}
+                            </span>
+                          </div>
+                        </div>
+
+                        {/* 강사 액션 버튼 */}
+                        <div className="flex gap-2">
+                          <Button 
+                            variant="outline" 
+                            size="sm"
+                            onClick={() => router.push(`/classes/attendance/${sched.classId}`)}
+                          >
+                            <CheckSquare className="size-4 md:mr-1"/> 
+                            <span className="hidden md:inline">출석부</span>
+                          </Button>
+                          <Button 
+                            variant="outline" 
+                            size="sm"
+                            onClick={() => router.push(`/classes/reports/${sched.classId}`)}
+                          >
+                            <FileText className="size-4 md:mr-1"/> 
+                            <span className="hidden md:inline">수업일지</span>
+                          </Button>
+                        </div>
+
+                      </div>
+                    ))
+                  ) : (
+                    <div className="flex items-center h-full text-sm text-muted">
+                      예정된 강의가 없습니다.
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
     </div>
   );
 }

--- a/src/app/(app)/classes/component/InstructorTimelineView.tsx
+++ b/src/app/(app)/classes/component/InstructorTimelineView.tsx
@@ -25,7 +25,9 @@ interface InstructorScheduleItem {
 
 export default function InstructorTimelineView({ classes = [] }: { classes?: ClassData[] }) {
   const router = useRouter();
-  const safeClasses = Array.isArray(classes) ? classes : [];
+  const safeClasses = useMemo(() => {
+  return Array.isArray(classes) ? classes : [];
+}, [classes]);
   
   // 오늘 요일 (1: 월요일 ~ 6: 토요일)
   const currentDay = new Date().getDay();

--- a/src/app/(app)/classes/component/StudentTimelineView.tsx
+++ b/src/app/(app)/classes/component/StudentTimelineView.tsx
@@ -23,7 +23,9 @@ interface ScheduleItem {
 }
 
 export default function StudentTimelineView({ classes = [] }: { classes?: ClassData[] }) {
-  const safeClasses = Array.isArray(classes) ? classes : [];
+  const safeClasses = useMemo(() => {
+  return Array.isArray(classes) ? classes : [];
+}, [classes]);
   
   // 오늘 요일 (1: 월요일 ~ 6: 토요일)
   const currentDay = new Date().getDay();

--- a/src/app/(app)/classes/component/StudentTimelineView.tsx
+++ b/src/app/(app)/classes/component/StudentTimelineView.tsx
@@ -1,45 +1,188 @@
 'use client';
 
-import React from 'react';
-import { Clock, BookOpen } from 'lucide-react';
+import { useMemo } from 'react';
+import { Clock, BookOpen, CalendarDays, AlertCircle } from 'lucide-react';
 import { ClassData } from '@/types/classes.types';
 
+// 월(1) ~ 토(6) 매핑 및 필터링용 데이터
+const TARGET_DAYS = [1, 2, 3, 4, 5, 6];
+const DAY_NAMES: Record<number, string> = {
+  1: '월', 2: '화', 3: '수', 4: '목', 5: '금', 6: '토'
+};
+
+// 개별 스케줄을 평탄화(Flatten)하기 위한 타입
+interface ScheduleItem {
+  classId: string;
+  subjectTitle: string;
+  instructorName: string;
+  classroomName: string;
+  targetDate: string | Date | null;
+  dayOfWeek: number;
+  startTime: string;
+  endTime: string;
+}
+
 export default function StudentTimelineView({ classes = [] }: { classes?: ClassData[] }) {
-  
-  // classes가 undefined/null인 경우를 대비해 확실한 배열로 변환
   const safeClasses = Array.isArray(classes) ? classes : [];
+  
+  // 오늘 요일 (1: 월요일 ~ 6: 토요일)
+  const currentDay = new Date().getDay();
+
+  // 데이터를 요일 및 시간별로 평탄화하고 정렬하는 로직
+  const allSchedules = useMemo(() => {
+    const schedules: ScheduleItem[] = [];
+    
+    safeClasses.forEach((cls) => {
+      if (!cls.schedules) return;
+      
+      cls.schedules.forEach((sched) => {
+        // 월~토(1~6)만 포함
+        if (TARGET_DAYS.includes(sched.dayOfWeek)) {
+          schedules.push({
+            classId: cls._id,
+            subjectTitle: typeof cls.subjectId === 'object' ? cls.subjectId.title : '수업',
+            instructorName: typeof cls.instructorId === 'object' ? cls.instructorId.username : '강사',
+            classroomName: typeof cls.classroomId === 'object' ? cls.classroomId.classroomName : '강의실 미정',
+            targetDate: cls.targetDate || null,
+            dayOfWeek: sched.dayOfWeek,
+            startTime: sched.startTime,
+            endTime: sched.endTime,
+          });
+        }
+      });
+    });
+
+    // 시작 시간 기준으로 오름차순 정렬
+    return schedules.sort((a, b) => a.startTime.localeCompare(b.startTime));
+  }, [safeClasses]);
+
+  // 오늘의 스케줄 필터링
+  const todaysSchedules = useMemo(() => {
+    return allSchedules.filter((s) => s.dayOfWeek === currentDay);
+  }, [allSchedules, currentDay]);
+
+  // 아무 수업도 없는 경우
+  if (safeClasses.length === 0) {
+    return (
+      <div className="text-center py-10 text-muted bg-paper rounded-3xl border border-border">
+        수강 중인 수업이 없습니다.
+      </div>
+    );
+  }
 
   return (
-    <div className="flex flex-col gap-4">
-      {/* 🚨 safeClasses를 사용 */}
-      {safeClasses.length === 0 ? (
-        <div className="text-center py-10 text-muted">수강 중인 수업이 없습니다.</div>
-      ) : (
-        safeClasses.map((cls) => (
-          <div key={cls._id} className="bg-paper border border-border rounded-3xl p-6 shadow-sm">
-            <div className="flex justify-between items-center mb-2">
-              <h3 className="text-lg font-bold text-ink">
-                {typeof cls.subjectId === 'object' ? cls.subjectId.title : '수업'}
-              </h3>
-              {cls.targetDate && (
-                <span className="text-xs font-bold text-red-500 bg-red-50 px-2 py-1 rounded-full">시험 예정</span>
-              )}
-            </div>
-            <div className="text-sm text-muted mb-4">
-              {typeof cls.instructorId === 'object' ? cls.instructorId.username : '강사'} 강사님
-            </div>
-            <div className="flex gap-4 text-sm text-ink/80">
-              <div className="flex items-center gap-1">
-                <Clock className="size-4 text-muted"/> {cls.schedules[0]?.startTime || '시간 미정'}
-              </div>
-              <div className="flex items-center gap-1">
-                <BookOpen className="size-4 text-muted"/> 
-                {typeof cls.classroomId === 'object' ? cls.classroomId.classroomName : '강의실 미정'}
-              </div>
-            </div>
+    <div className="flex flex-col gap-10">
+      
+      {/* 오늘의 시간표 섹션 */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <AlertCircle className="size-5 text-primary" />
+          <h2 className="text-xl font-extrabold text-ink">오늘의 시간표</h2>
+        </div>
+        
+        {/* 일요일이거나 오늘 수업이 없는 경우 */}
+        {todaysSchedules.length === 0 ? (
+          <div className="bg-paper border border-border rounded-2xl p-6 text-center text-muted">
+            오늘 예정된 수업이 없습니다.
           </div>
-        ))
-      )}
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2">
+            {todaysSchedules.map((sched, idx) => (
+              <div key={`today-${sched.classId}-${idx}`} className="bg-primary-bg border border-primary/20 rounded-2xl p-5 shadow-sm">
+                <div className="flex justify-between items-start mb-3">
+                  <div>
+                    <h3 className="text-lg font-bold text-primary">{sched.subjectTitle}</h3>
+                    <p className="text-sm text-primary/80 mt-0.5">{sched.instructorName} 강사님</p>
+                  </div>
+                  {sched.targetDate && (
+                    <span className="text-xs font-bold text-danger bg-danger-bg px-2.5 py-1 rounded-full">
+                      시험 예정
+                    </span>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 text-sm text-ink font-medium mt-4">
+                  <div className="flex items-center gap-2">
+                    <Clock className="size-4 text-primary" />
+                    <span>{sched.startTime} - {sched.endTime}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <BookOpen className="size-4 text-primary" />
+                    <span>{sched.classroomName}</span>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* 주간 시간표 섹션 (월~토) */}
+      <section>
+        <div className="flex items-center gap-2 mb-4">
+          <CalendarDays className="size-5 text-ink" />
+          <h2 className="text-xl font-extrabold text-ink">주간 시간표</h2>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {TARGET_DAYS.map((day) => {
+            const daySchedules = allSchedules.filter((s) => s.dayOfWeek === day);
+            const isToday = currentDay === day;
+
+            return (
+              <div 
+                key={day} 
+                className={`flex flex-col md:flex-row gap-4 p-5 rounded-2xl border ${
+                  isToday ? 'border-primary bg-primary-bg/50' : 'border-border bg-paper'
+                }`}
+              >
+                {/* 요일 헤더 */}
+                <div className="md:w-20 shrink-0 flex items-center md:items-start gap-2">
+                  <span className={`flex items-center justify-center w-10 h-10 rounded-xl font-extrabold text-lg ${
+                    isToday ? 'bg-primary text-background' : 'bg-border text-ink'
+                  }`}>
+                    {DAY_NAMES[day]}
+                  </span>
+                  {isToday && <span className="text-sm font-bold text-primary md:hidden">오늘</span>}
+                </div>
+
+                {/* 해당 요일의 스케줄 리스트 */}
+                <div className="flex flex-col gap-3 flex-1">
+                  {daySchedules.length > 0 ? (
+                    daySchedules.map((sched, idx) => (
+                      <div key={`weekly-${sched.classId}-${idx}`} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-3 bg-background rounded-xl border border-border shadow-sm">
+                        
+                        <div className="flex items-center gap-3">
+                          <div className="flex flex-col">
+                            <span className="font-bold text-ink">{sched.subjectTitle}</span>
+                            <span className="text-xs text-muted">{sched.instructorName} 강사님</span>
+                          </div>
+                        </div>
+
+                        <div className="flex items-center gap-4 text-sm font-medium text-ink/80">
+                          <div className="flex items-center gap-1.5">
+                            <Clock className="size-4 text-muted" />
+                            {sched.startTime} - {sched.endTime}
+                          </div>
+                          <div className="flex items-center gap-1.5">
+                            <BookOpen className="size-4 text-muted" />
+                            {sched.classroomName}
+                          </div>
+                        </div>
+
+                      </div>
+                    ))
+                  ) : (
+                    <div className="flex items-center h-full text-sm text-muted">
+                      예정된 수업이 없습니다.
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </section>
+
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,10 +8,12 @@
   --color-muted: #94a3b8;
   --color-primary: #2563eb;
   --color-primary-hover: #1d4ed8;
+  --color-primary-bg: #eff6ff; 
   --color-border: #e2e8f0;
   --color-accent: #fbbf24;
   --color-accent-2: #38bdf8;
   --color-danger: #ef4444;
+  --color-danger-bg: #fef2f2;
 }
 
 @layer base {


### PR DESCRIPTION
## 📌 작업 결과

- 강사/학생 시간표 페이지 디자인 변경

## 🔗 연관 이슈

- closes #21 

## ✅ 작업 체크리스트

- [x] 실행 시 에러가 없는지 확인했나요?
- [x] 코드 스타일 가이드(Prettier/ESLint)에 맞게 작성되었나요?
- [x] PR 설명이 충분히 상세한가요?

## 📸 스크린샷 (UI 변경 시 필수)
강사
<img width="742" height="727" alt="image" src="https://github.com/user-attachments/assets/ee4884cd-eed6-45b0-8d50-0342a95fb5d8" />


유저
<img width="737" height="718" alt="image" src="https://github.com/user-attachments/assets/eb820c6f-afe0-499f-8a8b-a643cb08cbab" />

